### PR TITLE
goserver: mandy: Switch to Oreo

### DIFF
--- a/goserver/mandy/mandy.go
+++ b/goserver/mandy/mandy.go
@@ -20,7 +20,7 @@ const AOSPA_MANIFEST_URL = GITHUB_HTTP + "/AOSPA/manifest.git"
 const MANIFEST_DEFAULT = "default.xml"
 const MANIFEST_AOSPA = "manifests/aospa.xml"
 
-const AOSPA_BRANCH = "nougat-mr2"
+const AOSPA_BRANCH = "oreo"
 const MANDY_BRANCH = AOSPA_BRANCH + "-bot"
 
 const MANDY_USERNAME = "PAMergebot"


### PR DESCRIPTION
As the manifest commit is going up and AOSPA N is reaching EOL, we can switch the
Mandy tracking branch to Oreo.