### PR TITLE
goserver: mandy: Switch to Oreo MR1

### DIFF
--- a/goserver/mandy/mandy.go
+++ b/goserver/mandy/mandy.go
@@ -22,7 +22,7 @@ const MANIFEST_AOSPA = "manifests/aospa.xml"
 
 const CAF_BRANCH = "caf"
 
-const AOSPA_BRANCH = "oreo"
+const AOSPA_BRANCH = "oreo-mr1"
 const MANDY_BRANCH = AOSPA_BRANCH + "-bot"
 
 const MANDY_USERNAME = "PAMergebot"


### PR DESCRIPTION
As CAF sources for Oreo 8.1.0 are out we will be switching to it.

Signed-off-by: Hernán Castañón <herna@paranoidandroid.co>